### PR TITLE
Fix flaky config test by running tests serially

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ base64 = "0.22.1"
 # Disable the needless_return lint globally
 # Note: This key does not exist in clippy.toml directly, hence inline attributes are preferred.
 
+[dev-dependencies]
+serial_test = "3.2.0"
+

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,5 +1,6 @@
 use client_rust_fix::config::Settings;
 use std::env;
+use serial_test::serial;
 
 fn setup() {
     // Clear all relevant environment variables before each test
@@ -15,6 +16,7 @@ fn setup() {
 }
 
 #[test]
+#[serial]
 fn test_settings_from_env_defaults() {
     setup();
     let settings = Settings::from_env().expect("load settings");
@@ -22,6 +24,7 @@ fn test_settings_from_env_defaults() {
 }
 
 #[test]
+#[serial]
 fn test_settings_custom_values() {
     setup();
     


### PR DESCRIPTION
## Summary
- ensure config tests don't clash on environment variables by using `serial_test`
- enable dev-dependency and annotate config tests

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68443aacbff4832887e62a5e3edb97e1