### PR TITLE
Improve tests and utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,5 @@ base64 = "0.22.1"
 
 [dev-dependencies]
 serial_test = "3.2.0"
+mockall = "0.12.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod scenarios {
     pub mod rfq_listen;
     pub mod rfq_publish;
     pub mod single_leg_order;
+    #[cfg(test)]
+    mod tests;
 }
 pub mod config;
 pub mod setup;

--- a/src/messages/utils/jwt_tests.rs
+++ b/src/messages/utils/jwt_tests.rs
@@ -2,38 +2,28 @@
 mod jwt_tests {
     use super::*;
     use jwtk::ecdsa::EcdsaPrivateKey;
-    
+
     fn setup_test_key() -> EcdsaPrivateKey {
-        // This would need a valid test key for actual testing
-        // For now, we'll just create a placeholder that would be replaced with actual test keys
-        let test_pem = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEILULtd0+Rx4/vMF/cVZ/SYU6Fo/HlgQF==\n-----END EC PRIVATE KEY-----";
+        let test_pem = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIFxrWIO1BpNTG1oiLRKc9fPHUuF3PHtx9RgNJAdZWhDBoAoGCCqGSM49\nAwEHoUQDQgAEdqr9eg/9hxsGwHatmOMyAQX2PfW1uj8RA4xKy3e4mUTO0+nUPlwl\n1ZqiYMy8ciFFRu6Jj7WDU/lVrqB1HvnCgQ==\n-----END EC PRIVATE KEY-----";
         EcdsaPrivateKey::from_pem(test_pem.as_bytes()).expect("Test key creation failed")
     }
-    
+
     #[test]
     fn test_generate_jwt_structure() {
-        // This test would verify the JWT has the correct structure
-        // Would need proper test keys to actually run
-        /*
         let key = setup_test_key();
         let api_key = "test_api_key".to_string();
         let now = 1234567890;
         let uri = "wss://test.example.com".to_string();
-        
         let token = generate_jwt(api_key.clone(), now, uri.clone(), key);
-        
-        // Verify token is not empty
         assert!(!token.is_empty());
-        
-        // Verify token has three parts separated by dots
-        let parts: Vec<&str> = token.split('.').collect();
-        assert_eq!(parts.len(), 3);
-        */
+        assert_eq!(token.split('.').count(), 3);
     }
-    
+
     #[test]
     fn test_generate_access_token() {
-        // Similar to above, would verify access token generation
-        // Would need proper test keys
+        let key = setup_test_key();
+        let token = generate_access_token("api", key, "wss://example.com");
+        assert!(!token.is_empty());
+        assert_eq!(token.split('.').count(), 3);
     }
 }

--- a/src/messages/utils/mod.rs
+++ b/src/messages/utils/mod.rs
@@ -1,17 +1,30 @@
 use chrono::Utc;
-use jwtk::{ecdsa::{EcdsaPrivateKey, EcdsaPublicKey}, sign, HeaderAndClaims};
-use log::{info, error};
+use jwtk::{
+    ecdsa::{EcdsaPrivateKey, EcdsaPublicKey},
+    sign, HeaderAndClaims,
+};
+use log::{error, info};
 use native_tls::{Certificate, TlsConnector, TlsStream};
 use quickfix_msg44::field_types::{OrdType, Side};
-use std::{env::var, fs::File, io::Read, net::TcpStream, thread::sleep, time::{Duration, SystemTime, UNIX_EPOCH}};
-use serde_json::{Value, Map};
+use serde_json::{Map, Value};
+use std::{
+    env::var,
+    fs::File,
+    io::Read,
+    net::TcpStream,
+    thread::sleep,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tungstenite::{client::IntoClientRequest, connect, http::HeaderValue, Message};
 use url::Url;
 
 #[allow(dead_code)]
 pub fn get_now() -> u64 {
-     // current datetime as seconds since 1970, used in scenarios executed below
-    SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards!!").as_secs()
+    // current datetime as seconds since 1970, used in scenarios executed below
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards!!")
+        .as_secs()
 }
 #[allow(dead_code)]
 pub fn get_attr(msg: &str, mytag: &str) -> String {
@@ -36,40 +49,50 @@ pub fn get_attr(msg: &str, mytag: &str) -> String {
 /// - server not found in config file
 #[allow(dead_code)]
 pub fn execute_ws_request(msg: &str) {
-
     assert!(!msg.is_empty(), "Error - message string is empty");
 
     // load target server based on env setting
-    let ws_server = var("PT_WS_SERVER")
-        .expect("PT_WS_SERVER must be set in the environment or .env file");
+    let ws_server =
+        var("PT_WS_SERVER").expect("PT_WS_SERVER must be set in the environment or .env file");
     info!("connecting to {:?}", ws_server);
 
     // load Power.Trade API key && private key from env
-    let api_key= var("PT_WS_API_KEY")
-        .expect("PT_WS_API_KEY must be set in the environment or .env file");
+    let api_key =
+        var("PT_WS_API_KEY").expect("PT_WS_API_KEY must be set in the environment or .env file");
     info!("PT_API_KEY: {:?}", api_key);
-
 
     let binding = var("PT_WS_API_SECRET")
         .expect("PT_WS_API_SECRET must be set in the environment or .env file");
-    let api_secret= binding.as_bytes();
+    let api_secret = binding.as_bytes();
 
     let url = match Url::parse(&ws_server) {
         Ok(url) => url,
         Err(error) => {
-            panic!("Error parsing server address {:?} -> {:?}", &ws_server, error);
+            panic!(
+                "Error parsing server address {:?} -> {:?}",
+                &ws_server, error
+            );
         }
     };
 
     // generate JWT token for authenticating at server side
-    let token: String = generate_access_token(&api_key, EcdsaPrivateKey::from_pem(api_secret).expect("error copnverting from PEM"), url.as_ref());
+    let token: String = generate_access_token(
+        &api_key,
+        EcdsaPrivateKey::from_pem(api_secret).expect("error copnverting from PEM"),
+        url.as_ref(),
+    );
 
     // log first X chars to assist with debugging issues
-    info!("Token generated for account {:?}\n{:?} ", api_key, token.clone().truncate(50));
+    info!(
+        "Token generated for account {:?}\n{:?} ",
+        api_key,
+        token.clone().truncate(50)
+    );
 
     // setup WS request with required Power.Trade header
     let mut req = url.into_client_request().unwrap();
-    req.headers_mut().append("X-Power-Trade", HeaderValue::from_str(&token).unwrap());
+    req.headers_mut()
+        .append("X-Power-Trade", HeaderValue::from_str(&token).unwrap());
 
     info!("Request headers: {:?}", req.headers());
     info!("Request body: {:?}", req.body());
@@ -78,10 +101,20 @@ pub fn execute_ws_request(msg: &str) {
     println!("Connecting to Power.Trade server: {}", &ws_server);
 
     let (mut socket, response) = connect(req).unwrap();
-    info!("Response from server {:?} -> {:?}", ws_server, response.status());
+    info!(
+        "Response from server {:?} -> {:?}",
+        ws_server,
+        response.status()
+    );
 
-    info!("Power.Trade websocket client now active for server {}", &ws_server);
-    println!("Power.Trade websocket client now active for server {}", &ws_server);
+    info!(
+        "Power.Trade websocket client now active for server {}",
+        &ws_server
+    );
+    println!(
+        "Power.Trade websocket client now active for server {}",
+        &ws_server
+    );
 
     //let result = connect(req);
     //let (mut socket, response) = match result {
@@ -98,12 +131,19 @@ pub fn execute_ws_request(msg: &str) {
     match socket.write(message.clone()) {
         Ok(result) => {
             socket.flush().expect("Error while flushing WS socket");
-            info!("Success writng message {} to server with result {:?} ", message.clone(), result);
-        },
-        Err(error) => {
-            error!("Error {:?} while writng message {} to server ", error,  message.clone());
+            info!(
+                "Success writng message {} to server with result {:?} ",
+                message.clone(),
+                result
+            );
         }
-
+        Err(error) => {
+            error!(
+                "Error {:?} while writng message {} to server ",
+                error,
+                message.clone()
+            );
+        }
     };
 
     // setup loop for checking received messages
@@ -115,14 +155,19 @@ pub fn execute_ws_request(msg: &str) {
     // loop on message receive -> TODO replace by event-driven style
     //
     loop {
-        sleep( Duration::from_secs(2));
+        sleep(Duration::from_secs(2));
         let msg: Message = socket.read().expect("Error while reading WS channel");
         info!("Received msg: {}", msg);
-        info!("Power.Trade websocket client sleeping [{} of {} epochs]", count, MAX_EPOCH);
+        info!(
+            "Power.Trade websocket client sleeping [{} of {} epochs]",
+            count, MAX_EPOCH
+        );
         count += 1;
         if count >= MAX_EPOCH {
             println!("Power.Trade websocket client closing after count of {count} epochs exceeded");
-            info!("\nPower.Trade websocket client closing after count of {count} epochs exceeded\n");
+            info!(
+                "\nPower.Trade websocket client closing after count of {count} epochs exceeded\n"
+            );
             break;
         } else {
             info!("Power.Trade websocket client waiting after count of {count} epochs vs max {MAX_EPOCH} ");
@@ -141,73 +186,75 @@ pub fn execute_ws_request(msg: &str) {
 ///
 #[allow(dead_code)]
 pub fn setup_tls_connection() -> TlsStream<TcpStream> {
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    //
+    // >> Assign/Load Settings
+    //
+    let host: String = var("PT_SERVER").expect("Error while retrieving PT_SERVER from .env file");
+    let port: String = String::from("2021"); // TODO - move this to .env vonfig
+    info!("Connecting to Host {:?}", host);
+    let server: String = format!("{host}:{port}");
+    info!("Connecting to Endpoint {server:?}");
 
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   //
-   // >> Assign/Load Settings
-   //
-   let host: String = var("PT_SERVER").expect("Error while retrieving PT_SERVER from .env file");
-   let port: String = String::from("2021"); // TODO - move this to .env vonfig
-   info!("Connecting to Host {:?}", host);
-   let server: String = format!("{host}:{port}");
-   info!("Connecting to Endpoint {server:?}");
+    //
+    // Load the public certificate from a file
+    //
+    let pubkey_path =
+        var("PT_PUBKEY_FILE").expect("Error while retrieving PT_PUBKEY_FILE from .env file"); //"private_cert.pem"; // TODO - take from env
+    info!("PUBKEY Path: {pubkey_path}");
+    let mut cert_file: File = File::open(pubkey_path).expect("Unable to open certificate file"); // TODO - from .env
+    let mut cert_data: Vec<u8> = Vec::new();
+    cert_file
+        .read_to_end(&mut cert_data)
+        .expect("Unable to read certificate file");
 
-   //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-   //
-   // Load the public certificate from a file
-   //
-   let pubkey_path = var("PT_PUBKEY_FILE").expect("Error while retrieving PT_PUBKEY_FILE from .env file"); //"private_cert.pem"; // TODO - take from env
-   info!("PUBKEY Path: {pubkey_path}");
-   let mut cert_file: File = File::open(pubkey_path).expect("Unable to open certificate file"); // TODO - from .env
-   let mut cert_data: Vec<u8> = Vec::new();
-   cert_file
-       .read_to_end(&mut cert_data)
-       .expect("Unable to read certificate file");
+    //
+    // Create Certificate object from the certificate data loaded from file
+    //
+    let cert = match Certificate::from_pem(&cert_data) {
+        Ok(cert) => {
+            info!("Found valid cert in file {cert_file:?}");
+            cert
+        }
+        Err(err) => {
+            error!("Error loading cert from PEM -> {err:?}");
+            panic!("Error loading cert from PEM -> {err:?}");
+        }
+    };
 
-   //
-   // Create Certificate object from the certificate data loaded from file
-   //
-   let cert = match Certificate::from_pem(&cert_data) {
-       Ok(cert) => {
-           info!("Found valid cert in file {cert_file:?}");
-           cert
-       }
-       Err(err) => {
-           error!("Error loading cert from PEM -> {err:?}");
-           panic!("Error loading cert from PEM -> {err:?}");
-       }
-   };
+    //
+    // Build instance of TLS connector
+    //
+    let connector: TlsConnector = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .add_root_certificate(cert)
+        .build()
+        .expect("Failed to build TLS connector");
+    info!("TLS Connection -> {connector:?}");
 
-   //
-   // Build instance of TLS connector
-   //
-   let connector: TlsConnector = TlsConnector::builder()
-       .danger_accept_invalid_certs(true)
-       .add_root_certificate(cert)
-       .build()
-       .expect("Failed to build TLS connector");
-   info!("TLS Connection -> {connector:?}");
+    //
+    // Connect to power.trade server over TCP
+    //
+    let stream = TcpStream::connect(&server).expect("Failed to connect to server");
+    info!("TLS Stream connecting to -> {server}");
 
-   //
-   // Connect to power.trade server over TCP
-   //
-   let stream = TcpStream::connect(&server).expect("Failed to connect to server");
-   info!("TLS Stream connecting to -> {server}");
+    //
+    // Setup TLS channel on top of TCP connection
+    //
+    let tls_stream = connector
+        .connect(&server, stream)
+        .expect("Failed to establish TLS session");
 
-   //
-   // Setup TLS channel on top of TCP connection
-   //
-   let tls_stream = connector
-       .connect(&server, stream)
-       .expect("Failed to establish TLS session");
+    // set 5 second timerout on reads
+    tls_stream
+        .get_ref()
+        .set_read_timeout(Some(Duration::new(5, 0)))
+        .expect("Failed to set read timeout");
 
-   // set 5 second timerout on reads
-   tls_stream.get_ref().set_read_timeout(Some(Duration::new(5, 0))).expect("Failed to set read timeout");
+    info!("TLS Stream -> {tls_stream:?}");
 
-   info!("TLS Stream -> {tls_stream:?}");
-
-   tls_stream
-
+    tls_stream
 }
 
 /// `get_pkey`
@@ -218,17 +265,19 @@ pub fn setup_tls_connection() -> TlsStream<TcpStream> {
 ///
 #[allow(dead_code)]
 pub fn get_pkey() -> EcdsaPrivateKey {
-
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     //
     // >> Read private key from file and load into 'EcdsaPrivateKey' object
     //
     // Read the PEM file
     //
-    let pem_path: String = var("PT_PEM_FILE").expect("Error while retrieving PT_PEM_FILE from .env file");
+    let pem_path: String =
+        var("PT_PEM_FILE").expect("Error while retrieving PT_PEM_FILE from .env file");
     let mut file = File::open(pem_path).expect("File name error");
     let mut pem_bytes: Vec<u8> = Vec::<u8>::new();
-    let size = file.read_to_end(&mut pem_bytes).expect("Error reading from file containing PEM content");
+    let size = file
+        .read_to_end(&mut pem_bytes)
+        .expect("Error reading from file containing PEM content");
     info!("Read {} bytes into string from PEM file '{:?}'", size, file);
 
     let pem = String::from_utf8(pem_bytes.clone()).expect("Error converting bytes to string");
@@ -240,7 +289,7 @@ pub fn get_pkey() -> EcdsaPrivateKey {
         Ok(key) => {
             info!("Priv key: {:?}", key);
             key
-        },
+        }
         Err(error) => {
             error!("Failed to process key: {error}");
             panic!("Error - failed to process PEM key: {error:?} "); // no way to continue, abort app
@@ -265,12 +314,11 @@ pub fn generate_jwt(apikey: String, now: u64, uri: String, my_key: EcdsaPrivateK
         .insert("nonce", now)
         .insert("sub", apikey)
         .set_iss(String::from("app.power.trade"))
-        .header_mut().alg ="ES256".to_string().into();
+        .header_mut()
+        .alg = "ES256".to_string().into();
 
     let token: String = match sign(&mut claims, &my_key) {
-        Ok(token) => {
-            token
-        },
+        Ok(token) => token,
         Err(error) => {
             error!("Error converting to private key: {error}");
             return String::new();
@@ -281,7 +329,6 @@ pub fn generate_jwt(apikey: String, now: u64, uri: String, my_key: EcdsaPrivateK
 
 #[allow(dead_code)]
 pub fn generate_access_token(api_key: &str, key: EcdsaPrivateKey, uri: &str) -> String {
-
     info!("Loading private key for account {}", api_key);
     //let key: EcdsaPrivateKey = match EcdsaPrivateKey::from_pem(pkey.as_bytes()) {
     //    Ok(my_key) => {
@@ -302,13 +349,17 @@ pub fn generate_access_token(api_key: &str, key: EcdsaPrivateKey, uri: &str) -> 
         .insert("client", "api".to_owned())
         .insert("sub", api_key.to_owned())
         .insert("uri", uri)
-        .insert("nonce",  Utc::now().timestamp())
+        .insert("nonce", Utc::now().timestamp())
         .set_iss(String::from("app.power.trade"))
-        .header_mut().alg ="ES256".to_string().into();
+        .header_mut()
+        .alg = "ES256".to_string().into();
 
-    info!("Adding claims {:?} to signed JWT for account {}", claims, api_key);
+    info!(
+        "Adding claims {:?} to signed JWT for account {}",
+        claims, api_key
+    );
 
-    let token: String = match sign( &mut claims, &key) {
+    let token: String = match sign(&mut claims, &key) {
         Ok(token) => {
             info!("JWT signed Ok with private key");
             token
@@ -338,7 +389,9 @@ pub fn process_key(pem: &str) -> Result<EcdsaPrivateKey, String> {
 #[allow(dead_code)]
 pub fn generate_order_id() -> u64 {
     let start = SystemTime::now();
-    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
     since_the_epoch.as_secs()
 }
 
@@ -357,8 +410,11 @@ pub fn generate_order_id() -> u64 {
 /// Panics if the public key cannot be generated from the private key
 #[allow(dead_code)]
 fn _generate_pubkey(mykey: EcdsaPrivateKey) -> EcdsaPublicKey {
-    let newpem: String = mykey.public_key_to_pem().expect("Error generating PEM file format from string");
-    let pk = EcdsaPublicKey::from_pem(newpem.as_bytes()).expect("Error creating public key from PEM");
+    let newpem: String = mykey
+        .public_key_to_pem()
+        .expect("Error generating PEM file format from string");
+    let pk =
+        EcdsaPublicKey::from_pem(newpem.as_bytes()).expect("Error creating public key from PEM");
     pk
 }
 
@@ -420,7 +476,6 @@ pub fn side_as_int(side: Side) -> u32 {
     }
 }
 
-
 #[allow(dead_code)]
 pub fn increment_seqnum(seqnum: std::sync::Arc<std::sync::Mutex<u32>>) -> u32 {
     let mut num = seqnum.lock().unwrap();
@@ -435,15 +490,18 @@ mod fix_msg_tests {
 
     #[test]
     fn test_message_equality() {
-        let fix_msg_txt = "8=FIX.4.2|9=12|35=D|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|".replace('|', "\x01");
+        let fix_msg_txt = "8=FIX.4.2|9=12|35=D|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|"
+            .replace('|', "\x01");
         let msg1: Message = Message::try_from_text(&fix_msg_txt).unwrap();
         let msg2: Message = Message::try_from_text(&fix_msg_txt).unwrap();
         assert_eq!(msg1.to_fix_string(), msg2.to_fix_string());
     }
     #[test]
     fn test_message_inequality() {
-        let fix_msg_txt1 = "8=FIX.4.2|9=12|35=D|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|".replace('|', "\x01");
-        let fix_msg_txt2 = "8=FIX.4.2|9=12|35=A|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|".replace('|', "\x01");
+        let fix_msg_txt1 = "8=FIX.4.2|9=12|35=D|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|"
+            .replace('|', "\x01");
+        let fix_msg_txt2 = "8=FIX.4.2|9=12|35=A|49=CLIENT|56=SERVER|34=2|52=20230612-12:34:56|"
+            .replace('|', "\x01");
         let msg1: Message = Message::try_from_text(&fix_msg_txt1).unwrap();
         let msg2: Message = Message::try_from_text(&fix_msg_txt2).unwrap();
         assert_ne!(msg1.to_fix_string(), msg2.to_fix_string());
@@ -453,50 +511,26 @@ mod fix_msg_tests {
 #[cfg(test)]
 mod fix_msg_enum_tests {
 
-    use quickfix_msg44::field_types::{OrdType, Side, TimeInForce};
     use crate::messages::utils::{order_type_to_char, side_as_int};
+    use quickfix_msg44::field_types::{OrdType, Side, TimeInForce};
 
-    #[test]
-    fn test_time_in_force_day() {
-        let tif = TimeInForce::Day;
-        assert_eq!(tif, TimeInForce::Day);
+    macro_rules! tif_test {
+        ($name:ident, $variant:ident) => {
+            #[test]
+            fn $name() {
+                let tif = TimeInForce::$variant;
+                assert_eq!(tif, TimeInForce::$variant);
+            }
+        };
     }
 
-    #[test]
-    fn test_time_in_force_good_till_cancel() {
-        let tif = TimeInForce::GoodTillCancel;
-        assert_eq!(tif, TimeInForce::GoodTillCancel);
-    }
-
-    #[test]
-    fn test_time_in_force_at_the_opening() {
-        let tif = TimeInForce::AtTheOpening;
-        assert_eq!(tif, TimeInForce::AtTheOpening);
-    }
-
-    #[test]
-    fn test_time_in_force_immediate_or_cancel() {
-        let tif = TimeInForce::ImmediateOrCancel;
-        assert_eq!(tif, TimeInForce::ImmediateOrCancel);
-    }
-
-    #[test]
-    fn test_time_in_force_fill_or_kill() {
-        let tif = TimeInForce::FillOrKill;
-        assert_eq!(tif, TimeInForce::FillOrKill);
-    }
-
-    #[test]
-    fn test_time_in_force_good_till_crossing() {
-        let tif = TimeInForce::GoodTillCrossing;
-        assert_eq!(tif, TimeInForce::GoodTillCrossing);
-    }
-
-    #[test]
-    fn test_time_in_force_good_till_date() {
-        let tif = TimeInForce::GoodTillDate;
-        assert_eq!(tif, TimeInForce::GoodTillDate);
-    }
+    tif_test!(tif_day, Day);
+    tif_test!(tif_good_till_cancel, GoodTillCancel);
+    tif_test!(tif_at_the_opening, AtTheOpening);
+    tif_test!(tif_immediate_or_cancel, ImmediateOrCancel);
+    tif_test!(tif_fill_or_kill, FillOrKill);
+    tif_test!(tif_good_till_crossing, GoodTillCrossing);
+    tif_test!(tif_good_till_date, GoodTillDate);
 
     #[test]
     fn test_time_in_force_debug_format() {
@@ -545,3 +579,8 @@ mod fix_msg_enum_tests {
         assert_eq!(side_int, 2);
     }
 }
+
+#[cfg(test)]
+mod jwt_tests;
+#[cfg(test)]
+mod tests;

--- a/src/messages/utils/tests.rs
+++ b/src/messages/utils/tests.rs
@@ -2,34 +2,34 @@
 mod utils_tests {
     use super::*;
     use jwtk::ecdsa::EcdsaPrivateKey;
-    
+
     #[test]
     fn test_get_now_returns_valid_timestamp() {
         let now = get_now();
         assert!(now > 0, "Timestamp should be greater than 0");
     }
-    
+
     #[test]
     fn test_generate_order_id_is_unique() {
         let id1 = generate_order_id();
         let id2 = generate_order_id();
         assert_ne!(id1, id2, "Generated order IDs should be unique");
     }
-    
+
     #[test]
     fn test_side_as_int_conversions() {
         use quickfix_msg44::field_types::Side;
         assert_eq!(side_as_int(Side::Buy), 1);
         assert_eq!(side_as_int(Side::Sell), 2);
     }
-    
+
     #[test]
     fn test_order_type_to_char_conversions() {
         use quickfix_msg44::field_types::OrdType;
         assert_eq!(order_type_to_char(OrdType::Market), '1');
         assert_eq!(order_type_to_char(OrdType::Limit), '2');
     }
-    
+
     #[test]
     fn test_process_key_with_valid_pem() {
         let valid_pem = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEILULtd0+Rx4/vMF/cVZ/SYU6Fo/HlgQF==\n-----END EC PRIVATE KEY-----";
@@ -37,11 +37,17 @@ mod utils_tests {
         // let result = process_key(valid_pem);
         // assert!(result.is_ok());
     }
-    
+
     #[test]
     fn test_process_key_with_invalid_pem() {
         let invalid_pem = "NOT A VALID PEM";
         let result = process_key(invalid_pem);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_attr_not_found() {
+        let msg = "8=FIX.4.4\x0135=D\x01";
+        assert_eq!(get_attr(msg, "55"), "");
     }
 }

--- a/src/scenarios/single_leg_order.rs
+++ b/src/scenarios/single_leg_order.rs
@@ -1,25 +1,25 @@
 use crate::messages::factory::FixMessageFactory;
 use crate::messages::utils::get_attr;
 use log::{error, info};
-use native_tls::TlsStream;
 use quickfix::{FieldMap, Message};
 use quickfix_msg44::field_types::Side;
 use std::{
     io::{ErrorKind, Read, Write},
-    net::TcpStream,
     option::Option::Some,
     sync::{Arc, Mutex},
     thread::sleep,
     time::Duration,
 };
 
-pub fn send_single_order(
+pub fn send_single_order<S>(
     apikey: &str,
-    tls_stream: Arc<Mutex<TlsStream<TcpStream>>>,
+    tls_stream: Arc<Mutex<S>>,
     order: Message,
     seqnum: u32,
     is_cancel_order: Option<bool>,
-) {
+) where
+    S: Read + Write + Send,
+{
     // assign parameter for cancel orders as a bool with default == 'true'
     let is_cancel_order = is_cancel_order.unwrap_or(true);
 
@@ -255,13 +255,15 @@ pub fn send_single_order(
     }
 }
 
-pub fn send_multiple_orders(
+pub fn send_multiple_orders<S>(
     apikey: &str,
-    tls_stream: Arc<Mutex<TlsStream<TcpStream>>>,
+    tls_stream: Arc<Mutex<S>>,
     orders: Vec<Message>,
     seqnum: u32,
     cancel: bool,
-) {
+) where
+    S: Read + Write + Send,
+{
     info!("Add-multiple-orders -> TLS: {:?}", tls_stream);
     for order in orders {
         info!("Sending multi/set order to be executed: {:?}", order);
@@ -269,7 +271,7 @@ pub fn send_multiple_orders(
     }
 }
 
-fn split_fix_messages(fix_messages: &str) -> Vec<String> {
+pub(crate) fn split_fix_messages(fix_messages: &str) -> Vec<String> {
     // Split the messages based on the "8=" tag which signifies the beginning of each message
     let mut messages: Vec<String> = fix_messages
         .split("8=FIX.4.4\x01")

--- a/src/scenarios/tests.rs
+++ b/src/scenarios/tests.rs
@@ -3,35 +3,83 @@ mod scenario_tests {
     use super::*;
     use mockall::predicate::*;
     use mockall::*;
-    use native_tls::TlsStream;
     use quickfix::Message;
-    use std::net::TcpStream;
-    
-    // This would require mockall for proper mocking
+    use quickfix_msg44::field_types::{OrdType, Side};
+    use std::sync::{Arc, Mutex};
+
     mock! {
-        TlsConnection {}
-        impl Write for TlsConnection {
+        Stream {}
+        impl Write for Stream {
             fn write(&mut self, buf: &[u8]) -> std::io::Result<usize>;
             fn flush(&mut self) -> std::io::Result<()>;
         }
-        impl Read for TlsConnection {
+        impl Read for Stream {
             fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>;
         }
     }
-    
+
     #[test]
     fn test_send_single_order_success() {
-        // This would test the send_single_order function with mocked TLS stream
-        // Would verify proper message flow and response handling
+        let mut stream = MockStream::new();
+        stream
+            .expect_write()
+            .times(1)
+            .returning(|buf| Ok(buf.len()));
+        stream.expect_read().times(1).returning(|buf| {
+            let resp = b"8=FIX.4.4\x0135=8\x0139=0\x0137=EXCH\x0111=ID\x01";
+            buf[..resp.len()].copy_from_slice(resp);
+            Ok(resp.len())
+        });
+        stream.expect_flush().returning(|| Ok(()));
+        let stream = Arc::new(Mutex::new(stream));
+
+        let order = FixMessageFactory::new_single_leg_order(
+            "key".to_string(),
+            1.0,
+            1.0,
+            "BTC-USD".to_string(),
+            Side::Buy,
+            OrdType::Limit,
+            1,
+        )
+        .unwrap();
+
+        send_single_order("key", stream, order, 1, Some(false));
     }
-    
+
     #[test]
     fn test_send_single_order_with_cancel() {
-        // This would test the order cancellation flow
+        let mut stream = MockStream::new();
+        stream
+            .expect_write()
+            .times(2)
+            .returning(|buf| Ok(buf.len()));
+        stream.expect_read().times(2).returning(|buf| {
+            let resp = b"8=FIX.4.4\x0135=8\x0139=0\x0137=EXCH\x0111=ID\x01";
+            buf[..resp.len()].copy_from_slice(resp);
+            Ok(resp.len())
+        });
+        stream.expect_flush().returning(|| Ok(()));
+        let stream = Arc::new(Mutex::new(stream));
+
+        let order = FixMessageFactory::new_single_leg_order(
+            "key".to_string(),
+            1.0,
+            1.0,
+            "BTC-USD".to_string(),
+            Side::Buy,
+            OrdType::Limit,
+            1,
+        )
+        .unwrap();
+
+        send_single_order("key", stream, order, 1, Some(true));
     }
-    
+
     #[test]
     fn test_rfq_publish_fix() {
-        // This would test the RFQ publishing functionality
+        let msgs = "8=FIX.4.4\x0135=8\x01".to_string();
+        let res = super::super::single_leg_order::split_fix_messages(&msgs);
+        assert_eq!(res.len(), 1);
     }
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use client_rust_fix::config::Settings;
-use std::env;
 use serial_test::serial;
+use std::env;
 
 fn setup() {
     // Clear all relevant environment variables before each test
@@ -27,7 +27,7 @@ fn test_settings_from_env_defaults() {
 #[serial]
 fn test_settings_custom_values() {
     setup();
-    
+
     // Set environment variables for this test
     env::set_var("PT_SYMBOL", "BTC-USD");
     env::set_var("PT_PRICE", "42.0");
@@ -38,13 +38,13 @@ fn test_settings_custom_values() {
     env::set_var("PT_HEARTBEAT_INTERVAL", "3");
     env::set_var("PT_HEARTBEAT_COUNT", "2");
     env::set_var("PT_TARGET_COMP_ID", "TEST");
-    
+
     // Print the environment variables to verify they're set correctly
     println!("PT_SYMBOL: {:?}", env::var("PT_SYMBOL"));
     println!("PT_PRICE: {:?}", env::var("PT_PRICE"));
-    
+
     let settings = Settings::from_env().unwrap();
-    
+
     // Verify all settings match expected values
     assert_eq!(settings.symbol, "BTC-USD");
     assert_eq!(settings.price, 42.0);
@@ -55,4 +55,20 @@ fn test_settings_custom_values() {
     assert_eq!(settings.heartbeat_interval, 3);
     assert_eq!(settings.heartbeat_count, 2);
     assert_eq!(settings.target_comp_id, "TEST");
+}
+
+#[test]
+#[serial]
+fn test_settings_invalid_price() {
+    setup();
+    env::set_var("PT_PRICE", "abc");
+    assert!(Settings::from_env().is_err());
+}
+
+#[test]
+#[serial]
+fn test_settings_invalid_heartbeat_interval() {
+    setup();
+    env::set_var("PT_HEARTBEAT_INTERVAL", "xyz");
+    assert!(Settings::from_env().is_err());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,12 +1,12 @@
 use client_rust_fix::messages::factory::FixMessageFactory;
-use client_rust_fix::messages::utils::{generate_order_id, side_as_int};
+
 use quickfix_msg44::field_types::{OrdType, Side};
 
 #[test]
 fn test_create_and_validate_order() {
     // This would be an integration test that creates an order message
     // and validates its structure without sending it
-    
+
     let api_key = "test_api_key".to_string();
     let price = 100.0;
     let quantity = 1.0;
@@ -14,21 +14,21 @@ fn test_create_and_validate_order() {
     let side = Side::Buy;
     let order_type = OrdType::Limit;
     let seqnum = 2;
-    
+
     let order_result = FixMessageFactory::new_single_leg_order(
-        api_key, price, quantity, symbol, side, order_type, seqnum
+        api_key, price, quantity, symbol, side, order_type, seqnum,
     );
-    
+
     assert!(order_result.is_ok());
-    
+
     if let Ok(order) = order_result {
         let order_str = order.to_fix_string().unwrap();
-        
+
         // Verify essential fields
-        assert!(order_str.contains("35=D"));  // NewOrderSingle
-        assert!(order_str.contains("54=1"));  // Side=Buy
-        assert!(order_str.contains("40=2"));  // OrdType=Limit
-        assert!(order_str.contains("55=BTC-USD"));  // Symbol
+        assert!(order_str.contains("35=D")); // NewOrderSingle
+        assert!(order_str.contains("54=1")); // Side=Buy
+        assert!(order_str.contains("40=2")); // OrdType=Limit
+        assert!(order_str.contains("55=BTC-USD")); // Symbol
     }
 }
 


### PR DESCRIPTION
## Summary
- clean up unused imports
- add invalid environment tests
- implement JWT tests
- expand utilities test coverage
- parameterize TimeInForce tests and expose modules for testing
- make order functions generic for easier mocking
- add scenario tests with mocks

## Testing
- `cargo test --quiet` *(fails: requires rustc 1.80)*

------
https://chatgpt.com/codex/tasks/task_e_684444b3e9cc8328a673a0df3acd3ad8